### PR TITLE
EW-002: ListQueues

### DIFF
--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -1,8 +1,11 @@
 import { Router } from 'express';
+import { awsCommandInput } from '@/services/aws-command-input';
 import healthCheck from '@/api/routes/health-check';
+import listQueues from '@/api/routes/list-queues';
 
 export default () => {
   const app: Router = Router();
   healthCheck(app);
+  listQueues(app, awsCommandInput);
   return app;
 };

--- a/server/src/api/routes/list-queues.ts
+++ b/server/src/api/routes/list-queues.ts
@@ -1,0 +1,15 @@
+import { Request, Response, Router } from 'express';
+import { ITerminal } from '@/interfaces/iterminal';
+import commands from '@/commands/sqs';
+
+const listQueues = (router: Router, terminal: ITerminal): void => {
+  const listQueuesRouter: Router = Router();
+  router.use('/', listQueuesRouter);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  listQueuesRouter.get('/', async (req: Request, res: Response): Promise<Response> => {
+    const listedQueues: string = await terminal.sendCommand(commands.listQueues);
+    return res.status(200).send(listedQueues).end();
+  });
+};
+
+export default listQueues;

--- a/server/src/commands/sqs.ts
+++ b/server/src/commands/sqs.ts
@@ -1,0 +1,7 @@
+import config from '@/config';
+
+const BASE_COMMAND = `aws --endpoint-url=http://${config.localstackUrl}:${config.localstackPort} sqs`;
+
+export default {
+  listQueues: `${BASE_COMMAND} list-queues`,
+};

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -3,5 +3,7 @@ import * as env from 'env-var';
 export default {
   eyewitnessApi: env.get('EYEWITNESS_API').default('/api').asString(),
   eyewitnessPort: env.get('EYEWITNESS_PORT').default('8080').asString(),
+  localstackUrl: env.get('LOCALSTACK_URL').default('localhost').asString(),
+  localstackPort: env.get('LOCALSTACK_PORT').default('4566').asString(),
   logLevel: env.get('LOG_LEVEL').default('debug').asString(),
 };

--- a/server/src/interfaces/iterminal.ts
+++ b/server/src/interfaces/iterminal.ts
@@ -1,0 +1,3 @@
+export interface ITerminal {
+  sendCommand(command: string): Promise<string>,
+}

--- a/server/src/services/aws-command-input.ts
+++ b/server/src/services/aws-command-input.ts
@@ -1,0 +1,9 @@
+import { ITerminal } from '@/interfaces/iterminal';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+export const cli = promisify(exec);
+
+export const awsCommandInput: ITerminal = {
+  sendCommand: async (command: string) => (await cli(command)).stdout,
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change provides the `listQueues` router to the homepage.

## Motivation and Context
My thinking behind this is that the front end can land on the homepage and do the generic request for all of the local sqs queues.  From there, the front end can slice up the queues in the response and make the requests for their individual statistics.

## How Has This Been Tested?
It shows up in the browser when we get a valid response

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.